### PR TITLE
fix readme due to renamed required plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ a Python version to another.
 Installing pyenv-virtualenv-migrate as a pyenv plugin will give you access to the
 `pyenv virtualenv-migrate` command.
 
-    git clone https://github.com/pyenv/pyenv-migrate.git $(pyenv root)/plugins/pyenv-migrate
+    git clone https://github.com/pyenv/pyenv-pip-migrate.git $(pyenv root)/plugins/pyenv-pip-migrate
     git clone https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv
     git clone https://github.com/ashwinvis/pyenv-virtualenv-migrate.git $(pyenv root)/plugins/pyenv-virtualenv-migrate
 

--- a/bin/pyenv-virtualenv-migrate
+++ b/bin/pyenv-virtualenv-migrate
@@ -23,7 +23,7 @@ if [ -z "$PYENV_ROOT" ]; then
 fi
 
 usage() {
-  pyenv-help virtualenv-migrate 2>/dev/null
+  pyenv-help virtualenv-migrate [venv name regex] 2>/dev/null
   [ -z "$1" ] || exit "$1"
 }
 
@@ -51,6 +51,13 @@ while getopts "dfh" arg; do
 done
 src="${@:$OPTIND:1}"
 dst="${@:$OPTIND+1:1}"
+regex="${@:$OPTIND+2:1}"
+shift $((OPTIND-1))
+
+if [ -n "$regex" ]; then
+    GREP_CMD="| grep -e $regex"
+fi
+
 shift $((OPTIND-1))
 [ -n "$src" ] || usage 1
 [ -n "$dst" ] || usage 1
@@ -65,7 +72,7 @@ pyenv-prefix "$dst" 1>/dev/null 2>&1 || {
   usage 1
 }
 
-VENVS=$(pyenv virtualenvs --skip-aliases | awk "/$src/{print \$1}")
+VENVS=$(pyenv virtualenvs --skip-aliases | awk "/$src/{print \$1}" $GREP_CMD)
 if [ -z "$VENVS" ]; then
   echo "pyenv: no virtualenvs to migrate from python version: $src" 1>&2
   usage 1


### PR DESCRIPTION
pyenv-migrate has been renamed to pyenv-pip-migrate