### PR TITLE
Remove orphaned venv symlink

### DIFF
--- a/bin/pyenv-virtualenv-migrate
+++ b/bin/pyenv-virtualenv-migrate
@@ -101,7 +101,11 @@ do
   printf "%s\n" "Migrating: ${VENV_SRC} -> ${VENV_DST}"
   pyenv virtualenv $FORCE "${dst}" "${VENV_DST}"
   pyenv migrate "${VENV_SRC}" "${VENV_DST}"
-  [ -n "$DELETE" ] && pyenv virtualenv-delete $FORCE "${VENV_SRC}" 1>/dev/null
+
+  if [ -n "$DELETE" ]; then
+    pyenv virtualenv-delete $FORCE "${VENV_SRC}" 1>/dev/null
+    rm -f "${PYENV_ROOT}/versions/_${VENV_NAME}_${src}"
+  fi
 done
 pyenv-rehash
 trap - ERR


### PR DESCRIPTION
This PR fixes the `-d` option by ensuring proper cleanup of all files, including the orphaned symlink (not handled by `pyenv virtual-delete` command) due to:

https://github.com/ashwinvis/pyenv-virtualenv-migrate/blob/f7d79e373e57664e2dd6038241a4886fca6ab604/bin/pyenv-virtualenv-migrate#L95-L99